### PR TITLE
Potential fix for code scanning alert no. 58: XML external entity expansion

### DIFF
--- a/soapserver/dvwsuserservice.js
+++ b/soapserver/dvwsuserservice.js
@@ -45,11 +45,8 @@ router.get('/', function (req, res, next) {
 });
 
 router.post('/', function (req, res, next) {
-    var options = {
-        noent: true,
-        dtdload: true
-    }
-    var xmlDoc = libxml.parseXml(req.body, options);
+    // Only use safe settings - do not allow external entity expansion or external DTDs
+    var xmlDoc = libxml.parseXml(req.body);
     var xmlchild = xmlDoc.get('//username');
     var username = xmlchild.text()
     mongoose.connect(connUri, { useNewUrlParser: true, useUnifiedTopology: true }, (err) => {


### PR DESCRIPTION
Potential fix for [https://github.com/in-s3c-dim/dvws-node/security/code-scanning/58](https://github.com/in-s3c-dim/dvws-node/security/code-scanning/58)

To fix the vulnerability, we should disable external entity expansion and external DTD loading when parsing user-provided XML with `libxmljs`. This is done by removing the `noent` and `dtdload` options, or by explicitly setting them to `false`. This change can be confined to the `router.post('/', ...)` handler, specifically the call to `libxml.parseXml`. In general:
- Remove the `options` object specifying `noent: true, dtdload: true`
- Either call `parseXml(req.body)` with no options, or specify these options as `false` if an object is required.
No additional libraries or complex logic are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
